### PR TITLE
Add OAuth flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { OrgListing } from "./components/org-listing";
 import { Home } from "./components/home";
 import { useProgressBar } from "./hooks";
 
+
 function App() {
   const isFetching = useIsFetching();
   useProgressBar(isFetching);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import { OrgListing } from "./components/org-listing";
 import { Home } from "./components/home";
 import { useProgressBar } from "./hooks";
 
-
 function App() {
   const isFetching = useIsFetching();
   useProgressBar(isFetching);

--- a/src/components/repo-form.tsx
+++ b/src/components/repo-form.tsx
@@ -66,7 +66,7 @@ function RepoFormComponent(props: FormikProps<Repo>) {
     <div>
 
       <div className="mt-3 text-center text-gray-500 text-sm">
-          { !user && <a href="https://github.com/login/oauth/authorize?client_id=0a8b4cd672b5e3dd8ea5&scope=repo" className="underline">click login first</a> }
+          { !user && <a href="https://github.com/login/oauth/authorize?client_id=0a8b4cd672b5e3dd8ea5&scope=repo" className="underline">If you wants see private repo, please click to login first</a> }
           { user && (
             <div className="flex flex-col items-center gap-3">
               <img src={user.avatar_url} width="72" height="72" />

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,5 @@
 import { useQuery, UseQueryOptions, UseQueryResult } from "react-query";
 import nprogress from "nprogress";
-import store from 'store2';
 import {
   fetchCommits,
   fetchFlatYaml,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,7 +9,6 @@ import {
   listCommitsResponse,
   fetchFilesFromRepo,
   fetchOrgRepos,
-  getUser,
 } from "../api";
 import { Repo, FlatDataTab, Repository } from "../types";
 import React from "react";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -16,13 +16,6 @@ import { Repo, FlatDataTab, Repository } from "../types";
 import React from "react";
 
 
-export function useGetUserName() {
-  const token = store.get("flat-viewer-pat")
-  return useQuery(["user"], () => getUser(token), {
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
-}
 // Hooks
 export function useFlatYaml(repo: Repo) {
   return useQuery(["flat-yaml", repo], () => fetchFlatYaml(repo), {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryOptions, UseQueryResult } from "react-query";
 import nprogress from "nprogress";
-
+import store from 'store2';
 import {
   fetchCommits,
   fetchFlatYaml,
@@ -10,10 +10,19 @@ import {
   listCommitsResponse,
   fetchFilesFromRepo,
   fetchOrgRepos,
+  getUser,
 } from "../api";
 import { Repo, FlatDataTab, Repository } from "../types";
 import React from "react";
 
+
+export function useGetUserName() {
+  const token = store.get("flat-viewer-pat")
+  return useQuery(["user"], () => getUser(token), {
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+}
 // Hooks
 export function useFlatYaml(repo: Repo) {
   return useQuery(["flat-yaml", repo], () => fetchFlatYaml(repo), {


### PR DESCRIPTION

There are two drawbacks for using `OAuth App`
- cannot reuse Github Private Page's token ( that means user may login twice, one for read private page, another for calling Github OAuth APIs ), 
-  since the github exchange token api not enable CORS, so the PR also require #2 

but there are no other way to eliminate ☝️  restriction